### PR TITLE
Activate minimatch option matchBase 

### DIFF
--- a/pr-review/src/main.ts
+++ b/pr-review/src/main.ts
@@ -26,7 +26,7 @@ export async function run(config: Config): Promise<void> {
 
   const throttlingOptions: ThrottlingOptions = { onSecondaryRateLimit: () => true, onRateLimit: () => true }
   const octokit = github.getOctokit(config.userToken, { baseUrl: config.githubApiUrl, throttle: throttlingOptions }, throttling, retry)
-  const matchOptions: MinimatchOptions = { dot: true, nocase: true }
+  const matchOptions: MinimatchOptions = { matchBase: true, dot: true, nocase: true }
   const repoRef = { owner: config.owner, repo: config.repo }
 
   core.info(`Get PR #${config.prNumber} from ${repoRef.owner}/${repoRef.repo}`)

--- a/pr-summary/src/main.ts
+++ b/pr-summary/src/main.ts
@@ -23,7 +23,7 @@ export async function run(config: Config): Promise<void> {
 
   const throttlingOptions: ThrottlingOptions = { onSecondaryRateLimit: () => true, onRateLimit: () => true }
   const octokit = github.getOctokit(config.userToken, { baseUrl: config.githubApiUrl, throttle: throttlingOptions }, throttling, retry)
-  const matchOptions: MinimatchOptions = { dot: true, nocase: true }
+  const matchOptions: MinimatchOptions = { matchBase: true, dot: true, nocase: true }
   const repoRef = { owner: config.owner, repo: config.repo }
 
   core.info(`Get PR #${config.prNumber} from ${repoRef.owner}/${repoRef.repo}`)


### PR DESCRIPTION
> If set, then patterns without slashes will be matched
against the basename of the path if it contains slashes. For example,
`a?b` would match the path `/xyz/123/acb`, but not `/xyz/acb/123`.
> <sup>https://github.com/isaacs/minimatch?tab=readme-ov-file#matchbase</sup>

- Before: 
  - `package-lock.json` pattern would match `package-lock.json` but not `subfolder/package-lock.json`
- After:
  - `package-lock.json` pattern would match `package-lock.json` as well as `subfolder/package-lock.json`

<!-- ai-assisted-summary-start -->
<!-- 787e24f7ec6584d3dd071aeca7a0f7e9124dbeb8...ce1d4b0aff67f0d804a9e914d4a63c7bbbd5dd33 -->
---

This change enhances file matching capabilities in both PR review and PR summary modules by enabling basename matching in addition to the existing dot file and case-insensitive matching options.

#### Walkthrough
- **Refactor:** Enhanced file matching configuration by adding `matchBase: true` option to MinimatchOptions in both PR review and summary modules, allowing pattern matching against file basenames rather than full paths for more flexible file filtering.

<sub>Model: anthropic--claude-4-sonnet | Prompt Tokens: 617 | Completion Tokens: 93</sub>
<!-- ai-assisted-summary-end -->