### PR TITLE
Support local disk read for context files

### DIFF
--- a/pr-summary/src/main.ts
+++ b/pr-summary/src/main.ts
@@ -4,6 +4,8 @@ import { retry } from "@octokit/plugin-retry"
 import { throttling, ThrottlingOptions } from "@octokit/plugin-throttling"
 import { ChatMessage } from "@sap-ai-sdk/orchestration"
 import { minimatch, MinimatchOptions } from "minimatch"
+import fs from "node:fs"
+import path from "node:path"
 import { inspect } from "node:util"
 import parseDiff from "parse-diff"
 import * as aiCoreClient from "./ai-core-client.js"
@@ -72,7 +74,7 @@ export async function run(config: Config): Promise<void> {
   }
 
   if (config.includeContextFiles.length > 0) {
-    core.startGroup(`Get static files for PR`)
+    core.startGroup(`Get static files for PR (GitHub API)`)
     const {
       data: { tree },
     } = await octokit.rest.git.getTree({ ...repoRef, tree_sha: pullRequest.head.sha, recursive: "true" })
@@ -86,6 +88,23 @@ export async function run(config: Config): Promise<void> {
           const result = [`Context file ${file.path}:`, "```", blob as unknown as string, "```", ""]
           core.info(result.join("\n"))
           content.push(...result)
+        }
+      }
+    }
+    core.startGroup(`Get static files for PR (runner's filesystem)`)
+    for (const entry of fs.readdirSync(".", { withFileTypes: true, recursive: true })) {
+      if (entry.isFile()) {
+        const filePath = entry.parentPath !== "." ? path.join(entry.parentPath, entry.name) : entry.name
+        if (config.includeContextFiles.some(pattern => minimatch(filePath, pattern, matchOptions))) {
+          if (config.excludeContextFiles.some(pattern => minimatch(filePath, pattern, matchOptions))) {
+            core.info(`Skipping context file ${filePath} (is excluded).`)
+          } else {
+            core.info(`Reading context file ${filePath}`)
+            const blob = fs.readFileSync(filePath, "utf8")
+            const result = [`Context file ${filePath}:`, "```", blob, "```", ""]
+            core.info(result.join("\n"))
+            content.push(...result)
+          }
         }
       }
     }


### PR DESCRIPTION
Right now, the AI-assisted actions don’t actually know anything about the file system during a workflow run. They just talk directly to the GitHub REST API to grab whatever they need from the repo. So, you don’t need to use actions/checkout, and even if you do, the action won’t look at the files on disk (at least for now).

Have the action look for the files locally first, and only fall back to grabbing them from the repo blobs if it can’t find them.