### PR TITLE
feat(pr-review): add summary-prompt input for context-aware review summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,4 @@ We as members, contributors, and leaders pledge to make participation in our com
 
 ## Licensing
 
-Copyright 2025 SAP SE or an SAP affiliate company and ai-assisted-github-actions contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/ai-assisted-github-actions).
+Copyright 2026 SAP SE or an SAP affiliate company and ai-assisted-github-actions contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/ai-assisted-github-actions).

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -7,5 +7,5 @@ SPDX-PackageComment = "The code in this project may include calls to APIs (\"API
 [[annotations]]
 path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 SAP SE or an SAP affiliate company and ai-assisted-github-actions contributors"
+SPDX-FileCopyrightText = "2026 SAP SE or an SAP affiliate company and ai-assisted-github-actions contributors"
 SPDX-License-Identifier = "Apache-2.0"

--- a/pr-review/README.md
+++ b/pr-review/README.md
@@ -98,6 +98,7 @@ Input parameters for the action:
 | `prompt`                        | The base prompt that is used to generate the review. <br /> Default: See [action.yml](action.yml#L36-L43)                                                                                                                                                                                                                            |
 | `prompt-addition`               | The addition to the base prompt that is used to generate the review.                                                                                                                                                                                                                                                                 |
 | `disclaimer-prompt`             | The prompt that is used to generate the disclaimer. <br /> Default: See [action.yml](action.yml#L51-L53)                                                                                                                                                                                                                             |
+| `summary-prompt`                | The prompt that is used to generate the summary shown in the review body. <br /> Default: `Append a brief summary of the key review findings. No lists, no headings.`                                                                                                                                                                |
 | `header-text`                   | Text to be inserted before the review.                                                                                                                                                                                                                                                                                               |
 | `footer-text`                   | Text to be inserted after the review.                                                                                                                                                                                                                                                                                                |
 | `previous-results`              | Define what to do with previous results. Possible values are `keep` or `hide`. <br /> Default: `keep`                                                                                                                                                                                                                                |
@@ -114,11 +115,12 @@ Input parameters for the action:
 
 Output parameters for the action:
 
-| Name       | Description                             |
-| ---------- | --------------------------------------- |
-| `comments` | An array of review comments for the PR. |
-| `reviewId` | The ID of the created GitHub PR review. |
-| `review`   | The created GitHub PR review.           |
+| Name       | Description                                               |
+| ---------- | --------------------------------------------------------- |
+| `comments` | The AI-generated review comments as a JSON array.         |
+| `reviewId` | The ID of the created GitHub PR review.                   |
+| `review`   | The full GitHub PR review object returned by the API.     |
+| `summary`  | The AI-generated summary text used in the PR review body. |
 
 ## Advanced Examples
 
@@ -206,6 +208,20 @@ jobs:
 
 ### Influence the Display Mode
 
+#### Customize the review summary:
+
+The `summary-prompt` parameter controls how the review body text is generated. The action runs a separate AI call with this prompt and the review findings as input.
+
+To add static content around it, see [Add a header or footer](#add-a-header-or-footer).
+
+```yaml
+- uses: ai-assisted-actions/pr-review@v2
+  with:
+    model: gpt-5.4
+    summary-prompt: |
+      Summarize the findings in bullet points, grouped by severity.
+```
+
 #### Add a header or footer:
 
 ```yaml
@@ -254,7 +270,7 @@ jobs:
 ```yaml
 - uses: SAP/ai-assisted-github-actions/pr-review@v3
   with:
-    model: anthropic--claude-3.5-sonnet
+    model: anthropic--claude-4.6-opus
 ```
 
 - The `model` parameter can be set to the executable ID of the [available generative AI models](https://me.sap.com/notes/3437766/E).

--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -51,9 +51,8 @@ inputs:
       Create a kind alternative for the following term: Here's a helpful review of your code with support from AI. Some insights are predictions, not guaranteed facts, so feel free to use what works best for you. Your decisions lead the way—AI is just here to assist.
       Do not use more than 80 words. Do not use quotation marks.
   summary-prompt:
-    description: "The prompt that is used to generate the summary shown in the review body."
+    description: "Prompt used to generate a summary of review findings in the review body. When not set, the LLM is called with only the disclaimer prompt (no review comments are sent)."
     required: false
-    default: "Append a brief summary of the key review findings. No lists, no headings."
 
   display-mode:
     description: "Defines where the review will be posted (`review-comment`, `review-comment-delta`, or `none`)."

--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -50,6 +50,10 @@ inputs:
     default: |
       Create a kind alternative for the following term: Here's a helpful review of your code with support from AI. Some insights are predictions, not guaranteed facts, so feel free to use what works best for you. Your decisions lead the way—AI is just here to assist.
       Do not use more than 80 words. Do not use quotation marks.
+  summary-prompt:
+    description: "The prompt that is used to generate the summary shown in the review body."
+    required: false
+    default: "Append a brief summary of the key review findings. No lists, no headings."
 
   display-mode:
     description: "Defines where the review will be posted (`review-comment`, `review-comment-delta`, or `none`)."
@@ -105,8 +109,14 @@ inputs:
     default: "${{ github.api_url }}"
 
 outputs:
+  comments:
+    description: "The AI-generated review comments as a JSON array."
   reviewId:
     description: "The ID of the created GitHub PR review."
+  review:
+    description: "The full GitHub PR review object returned by the API."
+  summary:
+    description: "The AI-generated summary text used in the PR review body."
 
 runs:
   using: node20

--- a/pr-review/src/config.ts
+++ b/pr-review/src/config.ts
@@ -137,7 +137,7 @@ export const config = {
   /** The prompt to use for the disclaimer. */
   disclaimerPrompt: parseInput(z.string(), "disclaimer-prompt"),
 
-  /** The prompt to use for the summary. */
+  /** The prompt to use for the summary. When empty, review comments are not sent to the LLM. */
   summaryPrompt: parseInput(z.string(), "summary-prompt"),
 
   /** The text that is placed before the review. */

--- a/pr-review/src/config.ts
+++ b/pr-review/src/config.ts
@@ -137,6 +137,9 @@ export const config = {
   /** The prompt to use for the disclaimer. */
   disclaimerPrompt: parseInput(z.string(), "disclaimer-prompt"),
 
+  /** The prompt to use for the summary. */
+  summaryPrompt: parseInput(z.string(), "summary-prompt"),
+
   /** The text that is placed before the review. */
   headerText: parseInput(z.string(), "header-text"),
 

--- a/pr-review/src/main.ts
+++ b/pr-review/src/main.ts
@@ -171,9 +171,7 @@ export async function run(config: Config): Promise<void> {
           role: "system",
           content: [config.disclaimerPrompt, config.summaryPrompt].join("\n\n"),
         },
-        ...(config.summaryPrompt
-          ? [{ role: "user" as const, content: `Review findings:\n${JSON.stringify(comments.map(({ path, body }) => ({ path, body })))}` }]
-          : []),
+        ...(config.summaryPrompt ? [{ role: "user" as const, content: `Review findings:\n${JSON.stringify(comments.map(({ path, body }) => ({ path, body })))}` }] : []),
       ])
       core.info(inspect(summary, { depth: undefined, colors: true }))
       core.setOutput("summary", summary)

--- a/pr-review/src/main.ts
+++ b/pr-review/src/main.ts
@@ -165,10 +165,16 @@ export async function run(config: Config): Promise<void> {
         )
       }
 
-      core.startGroup(`Ask LLM for a disclaimer text to add to the review description`)
-      const disclaimer = await aiCoreClient.chatCompletion([{ role: "user", content: config.disclaimerPrompt }])
-      core.info(inspect(disclaimer, { depth: undefined, colors: true }))
-      core.setOutput("disclaimer", disclaimer)
+      core.startGroup(`Ask LLM for a summary to add to the review description`)
+      const summary = await aiCoreClient.chatCompletion([
+        {
+          role: "system",
+          content: [config.disclaimerPrompt, config.summaryPrompt].join("\n"),
+        },
+        { role: "user", content: `Review findings:\n${JSON.stringify(comments.map(({ path, body }) => ({ path, body })))}` },
+      ])
+      core.info(inspect(summary, { depth: undefined, colors: true }))
+      core.setOutput("summary", summary)
 
       core.startGroup(`Create a PR review as comment with the generated comments`)
       const baseheadMaker = `<!-- ${base}...${head} -->`
@@ -180,8 +186,8 @@ export async function run(config: Config): Promise<void> {
         `Completion Tokens: ${aiCoreClient.getCompletionTokens()}`,
         base !== pullRequest.base.sha || head !== pullRequest.head.sha ? `Diff Range: ${base.slice(0, 7)}...${head.slice(0, 7)}` : "",
       ]
-      const modelMetadataFooter = config.showModelMetadataFooter ? `<sub>${metadata.filter(Boolean).join(" | ")}</sub>` : ""
-      const displayText = [markerStart, baseheadMaker, header, disclaimer, footer, modelMetadataFooter, markerEnd].filter(Boolean).join("\n")
+      const modelMetadataFooter = config.showModelMetadataFooter ? `\n<sub>${metadata.filter(Boolean).join(" | ")}</sub>` : ""
+      const displayText = [markerStart, baseheadMaker, header, summary, footer, modelMetadataFooter, markerEnd].filter(Boolean).join("\n")
 
       type CreateReviewParameter = Parameters<typeof octokit.rest.pulls.createReview>[0]
       const review: CreateReviewParameter = { ...repoRef, pull_number: config.prNumber, commit_id: head, event: "COMMENT", body: displayText, comments }

--- a/pr-review/src/main.ts
+++ b/pr-review/src/main.ts
@@ -169,9 +169,11 @@ export async function run(config: Config): Promise<void> {
       const summary = await aiCoreClient.chatCompletion([
         {
           role: "system",
-          content: [config.disclaimerPrompt, config.summaryPrompt].join("\n"),
+          content: [config.disclaimerPrompt, config.summaryPrompt].join("\n\n"),
         },
-        { role: "user", content: `Review findings:\n${JSON.stringify(comments.map(({ path, body }) => ({ path, body })))}` },
+        ...(config.summaryPrompt
+          ? [{ role: "user" as const, content: `Review findings:\n${JSON.stringify(comments.map(({ path, body }) => ({ path, body })))}` }]
+          : []),
       ])
       core.info(inspect(summary, { depth: undefined, colors: true }))
       core.setOutput("summary", summary)


### PR DESCRIPTION
**Context**: The action previously generated the review body text using `disclaimer-prompt` in isolation, with no access to the actual review findings. This meant the summary could not include context-aware content such as finding counts or severity breakdowns, since the findings only existed after the review was generated.

**Changes**:
- Added a new `summary-prompt` input parameter (default: `"Append a brief summary of the key review findings. No lists, no headings."`) to allow customizing the summary text
- Replaced the standalone `disclaimer-prompt` AI call with a combined system prompt that merges `disclaimer-prompt` and `summary-prompt`, passing the actual review findings as user content so the model can produce a context-aware summary
- Added missing `comments`, `review`, and `summary` output parameters to `action.yml` and updated their descriptions
- Updated README documentation to document the new `summary-prompt` parameter, the new outputs, and added the new "Customize the review summary" section